### PR TITLE
Add periodic cleanup timer for disconnected players

### DIFF
--- a/server.js
+++ b/server.js
@@ -272,6 +272,14 @@ function saveRoomsToFile() {
 // Load saved rooms on startup
 loadSavedRooms();
 
+// Periodically remove players that have been disconnected for more than 24h
+const CLEANUP_INTERVAL = 10 * 60 * 1000; // every 10 minutes
+setInterval(() => {
+  gameRooms.forEach((room) => {
+    room.cleanupDisconnectedPlayers();
+  });
+}, CLEANUP_INTERVAL);
+
 // Socket.IO connection handling
 io.on('connection', (socket) => {
   console.log('New client connected:', socket.id);


### PR DESCRIPTION
## Summary
- periodically remove inactive players

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688796a1a9088322bc8eff0d28a5ebb2