### PR TITLE
Fix chat input issue and mobile layout

### DIFF
--- a/multiplayer.js
+++ b/multiplayer.js
@@ -743,6 +743,13 @@ function createPlayerCard(player, isCurrentPlayer) {
 
 // Handle key press
 function handleKeyPress(e) {
+    // Ignore key presses while typing in the chat box or other inputs
+    if (document.activeElement === chatInput ||
+        document.activeElement.tagName === 'INPUT' ||
+        document.activeElement.tagName === 'TEXTAREA') {
+        return;
+    }
+
     if (gameOver || !gameState.gameActive) return;
     
     const key = e.key.toLowerCase();

--- a/styles.css
+++ b/styles.css
@@ -607,6 +607,7 @@ body {
         width: 100%;
         margin-top: 15px;
         height: 250px;
+        order: 3;
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent game keyboard handler when typing in inputs
- move chat panel below players on small screens

## Testing
- `npm install`
- `npm start` (then cancelled)


------
https://chatgpt.com/codex/tasks/task_e_6888b69360a48322ab45446338f3f51c